### PR TITLE
Fixed NavBar Items from stacking on logo in medium viewport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+/dotnet/LADP_EFC/.vs/LADP_EFC/FileContentIndex

--- a/react/src/components/navBar/NavBar.jsx
+++ b/react/src/components/navBar/NavBar.jsx
@@ -9,7 +9,7 @@ const NavBar = (props) => {
   const location = useLocation(); // Get the current location
   const isActive = (path) => (location.pathname === path ? styles.active : "");
   return (
-    <Navbar className={styles.background} expand="lg">
+    <Navbar className={styles.background} expand="md">
       <Container>
         <Nav className="me-auto col-md-5 justify-content-start justify-content-around">
           <Nav.Link


### PR DESCRIPTION
Fixed the nav items from stacking over the logo by changing the NavBar expand breakpoint to "md" instead of "lg". This means that when the medium breakpoint is reached (≥768px), the NavBar items will no longer be "vertically stacked" and this resolves the left items from also stacking on the logo. By allowing the navbar to expand at the medium breakpoint, no css was needed to be fixed/written. 


![image](https://github.com/user-attachments/assets/a2830629-6f17-4197-ae5d-f1e7e693a942)
![image](https://github.com/user-attachments/assets/7fa5d29d-49d0-42d2-95f4-eb2a0361e1d3)
