### PR TITLE
Updated CreateUserTest and created ConfirmAccountTest

### DIFF
--- a/dotnet/LADP.Tests/Repository/UserRepositoryTests.cs
+++ b/dotnet/LADP.Tests/Repository/UserRepositoryTests.cs
@@ -10,15 +10,15 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LADP.Tests.Repositories
+namespace LADP.Tests.Repository
 {
-    public class RepositoryUserTests : IDisposable
+    public class UserRepositoryTests : IDisposable
     {
         private readonly DataContext _context;
         private readonly Mock<IRepositoryEmail> _mockEmailRepo;
         private readonly RepositoryUser _repository;
 
-        public RepositoryUserTests()
+        public UserRepositoryTests()
         {
             // new DB per test class instance
             var options = new DbContextOptionsBuilder<DataContext>()


### PR DESCRIPTION
Refactored to avoid tests running on leftover users or tokens from previous tests.
Added IDisposable which xUnit calls Dispose() automatically to clean database after each test instance
Wrote test codes for updating user status and deleting the user's token afterwards. 